### PR TITLE
Xengineer/show brokedown cost graph

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,5 +17,6 @@
 //= require adminlte/dist/js/app.min
 //= require adminlte/plugins/flot/jquery.flot.js
 //= require adminlte/plugins/chartjs/Chart.js
+//= require adminlte/plugins/Chart.StackedBar.js/src/Chart.StackedBar.js
 //= require bootstrap-datepicker/core
 //= require bootstrap-datepicker/locales/bootstrap-datepicker.ja

--- a/app/assets/javascripts/project.js.coffee
+++ b/app/assets/javascripts/project.js.coffee
@@ -1,25 +1,21 @@
 $ ->
   costs = $.parseJSON(gon.costs)
-  graphData = []
   xaxis = []
-  console.log costs
-  $.each(costs, (k, v) ->
-    xaxis.push k
-    graphData.push v
+  graphdatasets = []
+
+  $.each(costs, (category, data) ->
+    graphdata = []
+    graphdata.label         = category
+    graphdata.fillColor     = "rgba(220,220,220,0.5)"
+    graphdata.strokeColor   = "rgba(220,220,220,0.8)"
+    graphdata.highlightFill = "rgba(220,220,220,0.75)"
+    graphdata.data          = data
+    graphdatasets.push graphdata
   )
 
   data = {
-    labels: xaxis,
-    datasets: [
-      {
-        label: "My First dataset",
-        fillColor: "rgba(220,220,220,0.5)",
-        strokeColor: "rgba(220,220,220,0.8)",
-        highlightFill: "rgba(220,220,220,0.75)",
-        highlightStroke: "rgba(220,220,220,1)",
-        data: graphData
-      }
-    ]
+    labels: gon.months,
+    datasets: graphdatasets
   };
   ctx = document.getElementById("cost_graph_canvas").getContext("2d")
-  graph = new Chart(ctx).Bar(data)
+  graph = new Chart(ctx).StackedBar(data)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -62,10 +62,18 @@ class ProjectsController < ApplicationController
   def aggregation_term_data
     @costs_term = {}
     @term_month = (@startday..@endday).select {|d| d.day == 1}
-    @term_month.each do |month|
-      cost = @project.actual.costs.term_cost(month, month.end_of_month).pluck(:cost).sum()
-      @costs_term[month.to_s] = cost
+    categories = @project.actual.costs.term_categories(@term_month.min, @term_month.max.end_of_month)
+    if @project.actual.costs.exists?
+      categories.each do |category|
+        term_cost = []
+        @term_month.each do |month|
+          term_category_cost = @project.actual.costs.term_category_cost(month, month.end_of_month, category)
+          term_cost.push(term_category_cost)
+        end
+        @costs_term[category.to_s] = term_cost
+      end
     end
     gon.costs = @costs_term.to_json
+    gon.months = @term_month
   end
 end

--- a/app/models/cost.rb
+++ b/app/models/cost.rb
@@ -5,4 +5,12 @@ class Cost < ActiveRecord::Base
   scope :term_cost, ->(start, endday) {
     where(order_date: Date.new(start.year, start.month, start.day)..Date.new(endday.year, endday.month, endday.day))
   }
+
+  scope :term_category_cost, ->(start, endday, category) {
+    where(order_date: Date.new(start.year, start.month, start.day)..Date.new(endday.year, endday.month, endday.day)).where(category: category).sum(:cost)
+  }
+
+  scope :term_categories, ->(start, endday) {
+    where(order_date: Date.new(start.year, start.month, start.day)..Date.new(endday.year, endday.month, endday.day)).pluck(:category)
+  }
 end

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/.gitignore
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/.gitignore
@@ -1,0 +1,8 @@
+
+.DS_Store
+
+node_modules/*
+custom/*
+
+docs/index.md
+bower_components

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/LICENSE
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Christian Stuff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/README.md
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/README.md
@@ -1,0 +1,16 @@
+Chart.StackedBar.js
+===================
+
+*StackedBar plugin for Chart.js* [chartjs.org](http://www.chartjs.org)
+
+## Documentation
+
+You can find the documentation under `/docs`
+
+## License
+
+Chart.StackedBar.js is available under the [MIT license](http://opensource.org/licenses/MIT).
+
+## Bugs & issues
+
+When reporting bugs or issues, if you could include a link to a simple [jsbin](http://jsbin.com) or similar demonstrating the issue, that'd be really helpful.

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/bower.json
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "Chart.StackedBar.js",
+  "version": "1.0.3",
+  "description": "StackedBar implementation for Chart.js",
+  "homepage": "https://github.com/nnnick/Chart.js",
+  "author": "Regaddi",
+  "main": [
+    "src/Chart.StackedBar.js"
+  ],
+  "dependencies": {
+    "Chart.js": ">= 1.0.0-beta"
+  }
+}

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/docs/Stacked-Bar-Chart.md
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/docs/Stacked-Bar-Chart.md
@@ -1,0 +1,141 @@
+---
+title: StackedBar Chart
+anchor: stacked-bar-chart
+---
+
+### Introduction
+A stacked bar chart is a way of showing data as bars.
+
+<div class="canvas-holder">
+	<canvas width="250" height="125"></canvas>
+</div>
+
+### Example usage
+```javascript
+var myStackedBarChart = new Chart(ctx).StackedBar(data, options);
+```
+
+### Data structure
+
+```javascript
+var data = {
+	labels: ["January", "February", "March", "April", "May", "June", "July"],
+	datasets: [
+		{
+			label: "My First dataset",
+			fillColor: "rgba(220,220,220,0.5)",
+			strokeColor: "rgba(220,220,220,0.8)",
+			highlightFill: "rgba(220,220,220,0.75)",
+			highlightStroke: "rgba(220,220,220,1)",
+			data: [65, 59, 80, 81, 56, 55, 40]
+		},
+		{
+			label: "My Second dataset",
+			fillColor: "rgba(151,187,205,0.5)",
+			strokeColor: "rgba(151,187,205,0.8)",
+			highlightFill: "rgba(151,187,205,0.75)",
+			highlightStroke: "rgba(151,187,205,1)",
+			data: [28, 48, 40, 19, 86, 27, 90]
+		}
+	]
+};
+```
+
+### Chart Options
+
+These are the customisation options specific to StackedBar charts. These options are merged with the [global chart configuration options](#getting-started-global-chart-configuration), and form the options of the chart.
+
+```javascript
+{
+	//Boolean - Whether the scale should start at zero, or an order of magnitude down from the lowest value
+	scaleBeginAtZero : true,
+
+	//Boolean - Whether grid lines are shown across the chart
+	scaleShowGridLines : true,
+
+	//String - Colour of the grid lines
+	scaleGridLineColor : "rgba(0,0,0,.05)",
+
+	//Number - Width of the grid lines
+	scaleGridLineWidth : 1,
+
+	//Boolean - If there is a stroke on each bar
+	barShowStroke : true,
+
+	//Number - Pixel width of the bar stroke
+	barStrokeWidth : 2,
+
+	//Number - Spacing between each of the X value sets
+	barValueSpacing : 5,
+
+	//Boolean - Whether bars should be rendered on a percentage base
+	relativeBars : false,
+
+	{% raw %}
+	//String - A legend template
+	legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].lineColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>",
+	{% endraw %}
+	
+	//Boolean - Hide labels with value set to 0
+	tooltipHideZero: false
+}
+```
+
+You can override these for your `Chart` instance by passing a second argument into the `StackedBar` method as an object with the keys you want to override.
+
+For example, we could have a stacked bar chart without a stroke on each bar by doing the following:
+
+```javascript
+new Chart(ctx).StackedBar(data, {
+	barShowStroke: false
+});
+// This will create a chart with all of the default options, merged from the global config,
+//  and the StackedBar chart defaults but this particular instance will have `barShowStroke` set to false.
+```
+
+We can also change these defaults values for each StackedBar type that is created, this object is available at `Chart.defaults.StackedBar`.
+
+### Prototype methods
+
+#### .getBarsAtEvent( event )
+
+Calling `getBarsAtEvent(event)` on your Chart instance passing an argument of an event, or jQuery event, will return the bar elements that are at that the same position of that event.
+
+```javascript
+canvas.onclick = function(evt){
+	var activeBars = myStackedBarChart.getBarsAtEvent(evt);
+	// => activeBars is an array of bars on the canvas that are at the same position as the click event.
+};
+```
+
+This functionality may be useful for implementing DOM based tooltips, or triggering custom behaviour in your application.
+
+#### .update( )
+
+Calling `update()` on your Chart instance will re-render the chart with any updated values, allowing you to edit the value of multiple existing points, then render those in one animated render loop.
+
+```javascript
+myStackedBarChart.datasets[0].bars[2].value = 50;
+// Would update the first dataset's value of 'March' to be 50
+myStackedBarChart.update();
+// Calling update now animates the position of March from 90 to 50.
+```
+
+#### .addData( valuesArray, label )
+
+Calling `addData(valuesArray, label)` on your Chart instance passing an array of values for each dataset, along with a label for those bars.
+
+```javascript
+// The values array passed into addData should be one for each dataset in the chart
+myStackedBarChart.addData([40, 60], "August");
+// The new data will now animate at the end of the chart.
+```
+
+#### .removeData( )
+
+Calling `removeData()` on your Chart instance will remove the first value for all datasets on the chart.
+
+```javascript
+myStackedBarChart.removeData();
+// The chart will now animate and remove the first bar
+```

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/package.json
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "Chart.StackedBar.js",
+  "homepage": "http://www.chartjs.org",
+  "description": "StackedBar implementation for Chart.js",
+  "private": true,
+  "version": "1.0.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Regaddi/Chart.StackedBar.js.git"
+  },
+  "dependences": {
+    "Chart.js": ">= 1.0.0-beta"
+  },
+  "main": "src/Chart.StackedBar.js",
+  "devDependencies": {
+    "gulp": "3.5.x",
+    "gulp-concat": "~2.1.x",
+    "gulp-uglify": "~0.2.x",
+    "gulp-util": "~2.2.x",
+    "gulp-jshint": "~1.5.1",
+    "gulp-size": "~0.4.0",
+    "gulp-connect": "~2.0.5"
+  }
+}

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/samples/stacked-bar.html
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/samples/stacked-bar.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Stacked Bar Chart</title>
+		<script src="http://www.chartjs.org/assets/Chart.min.js"></script>
+		<script src="../src/Chart.StackedBar.js"></script>
+		<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+	</head>
+	<body>
+		<div style="width: 50%">
+			<canvas id="canvas" height="450" width="600"></canvas>
+		</div>
+
+		<button id="randomizeData">Randomize Data</button>
+
+	<script>
+	var randomScalingFactor = function(){ return Math.round(Math.random()*100)};
+	var randomColorFactor = function(){ return Math.round(Math.random()*255)};
+
+	var barChartData = {
+		labels : ["January","February","March","April","May","June","July"],
+		datasets : [
+			{
+				fillColor : "rgba(220,220,220,0.5)",
+				strokeColor : "rgba(220,220,220,0.8)",
+				highlightFill: "rgba(220,220,220,0.75)",
+				highlightStroke: "rgba(220,220,220,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			},
+			{
+				fillColor : "rgba(151,187,205,0.5)",
+				strokeColor : "rgba(151,187,205,0.8)",
+				highlightFill : "rgba(151,187,205,0.75)",
+				highlightStroke : "rgba(151,187,205,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			},
+			{
+				fillColor : "rgba(240,73,73,0.5)",
+				strokeColor : "rgba(240,73,73,0.8)",
+				highlightFill : "rgba(240,73,73,0.75)",
+				highlightStroke : "rgba(240,73,73,1)",
+				data : [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()]
+			}
+		]
+	};
+	window.onload = function(){
+		var ctx = document.getElementById("canvas").getContext("2d");
+		window.myBar = new Chart(ctx).StackedBar(barChartData, {
+			responsive : true
+		});
+
+		$('#randomizeData').click(function(){
+			barChartData.datasets[0].fillColor = 'rgba(' + randomColorFactor() + ',' + randomColorFactor() + ',' + randomColorFactor() + ',.7)';
+			barChartData.datasets[0].data = [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()];
+
+			barChartData.datasets[1].fillColor = 'rgba(' + randomColorFactor() + ',' + randomColorFactor() + ',' + randomColorFactor() + ',.7)';
+			barChartData.datasets[1].data = [randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor(),randomScalingFactor()];
+
+			window.myBar.update();
+		});
+	};
+	</script>
+	</body>
+</html>

--- a/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/src/Chart.StackedBar.js
+++ b/vendor/assets/bower_components/adminlte/plugins/Chart.StackedBar.js/src/Chart.StackedBar.js
@@ -1,0 +1,556 @@
+(function (factory) {
+	"use strict";
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(['chart.js'], factory);
+	} else if (typeof exports === 'object') {
+		// Node/CommonJS
+		module.exports = factory(require('chart.js'));
+	} else {
+		// Global browser
+		factory(Chart);
+	}
+}(function (Chart) {
+	"use strict";
+
+	var helpers = Chart.helpers;
+
+	var defaultConfig = {
+		scaleBeginAtZero : true,
+
+		//Boolean - Whether grid lines are shown across the chart
+		scaleShowGridLines : true,
+
+		//String - Colour of the grid lines
+		scaleGridLineColor : "rgba(0,0,0,.05)",
+
+		//Number - Width of the grid lines
+		scaleGridLineWidth : 1,
+
+        //Boolean - Whether to show horizontal lines (except X axis)
+		scaleShowHorizontalLines: true,
+
+		//Boolean - Whether to show vertical lines (except Y axis)
+		scaleShowVerticalLines: true,
+
+		//Boolean - If there is a stroke on each bar
+		barShowStroke : true,
+
+		//Number - Pixel width of the bar stroke
+		barStrokeWidth : 2,
+
+		//Number - Spacing between each of the X value sets
+		barValueSpacing : 5,
+
+		//Boolean - Whether bars should be rendered on a percentage base
+		relativeBars : false,
+
+		//String - A legend template
+		legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span style=\"background-color:<%=datasets[i].fillColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>",
+
+		//Boolean - Show total legend
+		showTotal: false,
+
+		//String - Color of total legend
+		totalColor: '#fff',
+
+		//String - Total Label
+		totalLabel: 'Total',
+
+		//Boolean - Hide labels with value set to 0
+		tooltipHideZero: false
+	};
+
+	Chart.Type.extend({
+		name: "StackedBar",
+		defaults : defaultConfig,
+		initialize:  function(data){
+			//Expose options as a scope variable here so we can access it in the ScaleClass
+			var options = this.options;
+
+			// Save data as a source for updating of values & methods
+			this.data = data;
+
+			this.ScaleClass = Chart.Scale.extend({
+				offsetGridLines : true,
+				calculateBarX : function(barIndex){
+					return this.calculateX(barIndex);
+				},
+				calculateBarY : function(datasets, dsIndex, barIndex, value){
+					var offset = 0,
+						sum = 0;
+
+					for(var i = 0; i < datasets.length; i++) {
+						sum += datasets[i].bars[barIndex].value;
+					}
+					for(i = dsIndex; i < datasets.length; i++) {
+						if(i === dsIndex && value) {
+							offset += value;
+						} else {
+							offset = +offset + +datasets[i].bars[barIndex].value;
+						}
+					}
+
+					if(options.relativeBars) {
+						offset = offset / sum * 100;
+					}
+
+					return this.calculateY(offset);
+				},
+				calculateBaseWidth : function(){
+					return (this.calculateX(1) - this.calculateX(0)) - (2*options.barValueSpacing);
+				},
+				calculateBaseHeight : function(){
+					return (this.calculateY(1) - this.calculateY(0));
+				},
+				calculateBarWidth : function(datasetCount){
+					//The padding between datasets is to the right of each bar, providing that there are more than 1 dataset
+					return this.calculateBaseWidth();
+				},
+				calculateBarHeight : function(datasets, dsIndex, barIndex, value) {
+					var sum = 0;
+
+					for(var i = 0; i < datasets.length; i++) {
+						sum += datasets[i].bars[barIndex].value;
+					}
+
+					if(!value) {
+						value = datasets[dsIndex].bars[barIndex].value;
+					}
+
+					if(options.relativeBars) {
+						value = value / sum * 100;
+					}
+
+					return this.calculateY(value);
+				}
+			});
+
+			this.datasets = [];
+
+			//Set up tooltip events on the chart
+			if (this.options.showTooltips){
+				helpers.bindEvents(this, this.options.tooltipEvents, function(evt){
+					var activeBars = (evt.type !== 'mouseout') ? this.getBarsAtEvent(evt) : [];
+
+					this.eachBars(function(bar){
+						bar.restore(['fillColor', 'strokeColor']);
+					});
+					helpers.each(activeBars, function(activeBar){
+						activeBar.fillColor = activeBar.highlightFill;
+						activeBar.strokeColor = activeBar.highlightStroke;
+					});
+					this.showTooltip(activeBars);
+				});
+			}
+
+			//Declare the extension of the default point, to cater for the options passed in to the constructor
+			this.BarClass = Chart.Rectangle.extend({
+				strokeWidth : this.options.barStrokeWidth,
+				showStroke : this.options.barShowStroke,
+				ctx : this.chart.ctx
+			});
+
+			//Iterate through each of the datasets, and build this into a property of the chart
+			helpers.each(data.datasets,function(dataset,datasetIndex){
+
+				var datasetObject = {
+					label : dataset.label || null,
+					fillColor : dataset.fillColor,
+					strokeColor : dataset.strokeColor,
+					bars : []
+				};
+
+				this.datasets.push(datasetObject);
+
+				helpers.each(dataset.data,function(dataPoint,index){
+					if(!helpers.isNumber(dataPoint)){
+						dataPoint = 0;
+					}
+					//Add a new point for each piece of data, passing any required data to draw.
+					//Add 0 as value if !isNumber (e.g. empty values are useful when 0 values should be hidden in tooltip)
+					datasetObject.bars.push(new this.BarClass({
+						value : dataPoint,
+						label : data.labels[index],
+						datasetLabel: dataset.label,
+						strokeColor : dataset.strokeColor,
+						fillColor : dataset.fillColor,
+						highlightFill : dataset.highlightFill || dataset.fillColor,
+						highlightStroke : dataset.highlightStroke || dataset.strokeColor
+					}));
+				},this);
+
+			},this);
+
+			this.buildScale(data.labels);
+
+			this.eachBars(function(bar, index, datasetIndex){
+				helpers.extend(bar, {
+					base: this.scale.endPoint,
+					height: 0,
+					width : this.scale.calculateBarWidth(this.datasets.length),
+					x: this.scale.calculateBarX(index),
+					y: this.scale.endPoint
+				});
+				bar.save();
+			}, this);
+
+			this.render();
+		},
+		showTooltip : function(ChartElements, forceRedraw){
+			// Only redraw the chart if we've actually changed what we're hovering on.
+			if (typeof this.activeElements === 'undefined') this.activeElements = [];
+
+			helpers = Chart.helpers;
+
+			var isChanged = (function(Elements){
+				var changed = false;
+
+				if (Elements.length !== this.activeElements.length){
+					changed = true;
+					return changed;
+				}
+
+				helpers.each(Elements, function(element, index){
+					if (element !== this.activeElements[index]){
+						changed = true;
+					}
+				}, this);
+				return changed;
+			}).call(this, ChartElements);
+
+			if (!isChanged && !forceRedraw){
+				return;
+			}
+			else{
+				this.activeElements = ChartElements;
+			}
+			this.draw();
+			if(this.options.customTooltips){
+				this.options.customTooltips(false);
+			}
+			if (ChartElements.length > 0){
+				// If we have multiple datasets, show a MultiTooltip for all of the data points at that index
+				if (this.datasets && this.datasets.length > 1) {
+					var dataArray,
+					dataIndex;
+
+					for (var i = this.datasets.length - 1; i >= 0; i--) {
+						dataArray = this.datasets[i].points || this.datasets[i].bars || this.datasets[i].segments;
+						dataIndex = helpers.indexOf(dataArray, ChartElements[0]);
+						if (dataIndex !== -1){
+							break;
+						}
+					}
+					var tooltipLabels = [],
+					tooltipColors = [],
+					medianPosition = (function(index) {
+
+						// Get all the points at that particular index
+						var Elements = [],
+						dataCollection,
+						xPositions = [],
+						yPositions = [],
+						xMax,
+						yMax,
+						xMin,
+						yMin;
+						helpers.each(this.datasets, function(dataset){
+							dataCollection = dataset.points || dataset.bars || dataset.segments;
+							if (dataCollection[dataIndex] && dataCollection[dataIndex].hasValue()){
+								Elements.push(dataCollection[dataIndex]);
+							}
+						});
+
+						var total = {
+							datasetLabel: this.options.totalLabel,
+							value: 0,
+							fillColor: this.options.totalColor,
+							strokeColor: this.options.totalColor
+						};
+
+						helpers.each(Elements, function(element) {
+							if (this.options.tooltipHideZero && element.value === 0) {
+								return;
+							}
+
+							xPositions.push(element.x);
+							yPositions.push(element.y);
+
+							total.value += element.value;
+
+							//Include any colour information about the element
+							tooltipLabels.push(helpers.template(this.options.multiTooltipTemplate, element));
+							tooltipColors.push({
+								fill: element._saved.fillColor || element.fillColor,
+								stroke: element._saved.strokeColor || element.strokeColor
+							});
+
+						}, this);
+
+						if (this.options.showTotal) {
+							tooltipLabels.push(helpers.template(this.options.multiTooltipTemplate, total));
+							tooltipColors.push({
+								fill: total.fillColor,
+								stroke: total.strokeColor
+							});
+						}
+
+						yMin = helpers.min(yPositions);
+						yMax = helpers.max(yPositions);
+
+						xMin = helpers.min(xPositions);
+						xMax = helpers.max(xPositions);
+
+						return {
+							x: (xMin > this.chart.width/2) ? xMin : xMax,
+							y: (yMin + yMax)/2
+						};
+					}).call(this, dataIndex);
+
+					new Chart.MultiTooltip({
+						x: medianPosition.x,
+						y: medianPosition.y,
+						xPadding: this.options.tooltipXPadding,
+						yPadding: this.options.tooltipYPadding,
+						xOffset: this.options.tooltipXOffset,
+						fillColor: this.options.tooltipFillColor,
+						textColor: this.options.tooltipFontColor,
+						fontFamily: this.options.tooltipFontFamily,
+						fontStyle: this.options.tooltipFontStyle,
+						fontSize: this.options.tooltipFontSize,
+						titleTextColor: this.options.tooltipTitleFontColor,
+						titleFontFamily: this.options.tooltipTitleFontFamily,
+						titleFontStyle: this.options.tooltipTitleFontStyle,
+						titleFontSize: this.options.tooltipTitleFontSize,
+						cornerRadius: this.options.tooltipCornerRadius,
+						labels: tooltipLabels,
+						legendColors: tooltipColors,
+						legendColorBackground : this.options.multiTooltipKeyBackground,
+						title: ChartElements[0].label,
+						chart: this.chart,
+						ctx: this.chart.ctx,
+						custom: this.options.customTooltips
+					}).draw();
+
+				} else {
+					helpers.each(ChartElements, function(Element) {
+						var tooltipPosition = Element.tooltipPosition();
+						new Chart.Tooltip({
+							x: Math.round(tooltipPosition.x),
+							y: Math.round(tooltipPosition.y),
+							xPadding: this.options.tooltipXPadding,
+							yPadding: this.options.tooltipYPadding,
+							fillColor: this.options.tooltipFillColor,
+							textColor: this.options.tooltipFontColor,
+							fontFamily: this.options.tooltipFontFamily,
+							fontStyle: this.options.tooltipFontStyle,
+							fontSize: this.options.tooltipFontSize,
+							caretHeight: this.options.tooltipCaretSize,
+							cornerRadius: this.options.tooltipCornerRadius,
+							text: helpers.template(this.options.tooltipTemplate, Element),
+							chart: this.chart,
+							custom: this.options.customTooltips
+						}).draw();
+					}, this);
+				}
+			}
+			return this;
+		},
+		update : function(){
+
+			//Iterate through each of the datasets, and build this into a property of the chart
+			helpers.each(this.data.datasets,function(dataset,datasetIndex){
+
+				helpers.extend(this.datasets[datasetIndex], {
+					label : dataset.label || null,
+					fillColor : dataset.fillColor,
+					strokeColor : dataset.strokeColor,
+				});
+
+				helpers.each(dataset.data,function(dataPoint,index){
+					helpers.extend(this.datasets[datasetIndex].bars[index], {
+						value : dataPoint,
+						label : this.data.labels[index],
+						datasetLabel: dataset.label,
+						strokeColor : dataset.strokeColor,
+						fillColor : dataset.fillColor,
+						highlightFill : dataset.highlightFill || dataset.fillColor,
+						highlightStroke : dataset.highlightStroke || dataset.strokeColor
+					});
+				},this);
+
+			},this);
+
+
+			this.scale.update();
+			// Reset any highlight colours before updating.
+			helpers.each(this.activeElements, function(activeElement){
+				activeElement.restore(['fillColor', 'strokeColor']);
+			});
+
+			this.eachBars(function(bar){
+				bar.save();
+			});
+			this.render();
+		},
+		eachBars : function(callback){
+			helpers.each(this.datasets,function(dataset, datasetIndex){
+				helpers.each(dataset.bars, callback, this, datasetIndex);
+			},this);
+		},
+		getBarsAtEvent : function(e){
+			var barsArray = [],
+				eventPosition = helpers.getRelativePosition(e),
+				datasetIterator = function(dataset){
+					barsArray.push(dataset.bars[barIndex]);
+				},
+				barIndex;
+
+			for (var datasetIndex = 0; datasetIndex < this.datasets.length; datasetIndex++) {
+				for (barIndex = 0; barIndex < this.datasets[datasetIndex].bars.length; barIndex++) {
+					if (this.datasets[datasetIndex].bars[barIndex].inRange(eventPosition.x,eventPosition.y)){
+						helpers.each(this.datasets, datasetIterator);
+						return barsArray;
+					}
+				}
+			}
+
+			return barsArray;
+		},
+		buildScale : function(labels){
+			var self = this;
+
+			var dataTotal = function(){
+				var values = [];
+				helpers.each(self.datasets, function(dataset) {
+					helpers.each(dataset.bars, function(bar, barIndex) {
+						if(!values[barIndex]) values[barIndex] = 0;
+						if(self.options.relativeBars) {
+							values[barIndex] = 100;
+						} else {
+							values[barIndex] = +values[barIndex] + +bar.value;
+						}
+					});
+				});
+				return values;
+			};
+
+			var scaleOptions = {
+				templateString : this.options.scaleLabel,
+				height : this.chart.height,
+				width : this.chart.width,
+				ctx : this.chart.ctx,
+				textColor : this.options.scaleFontColor,
+				fontSize : this.options.scaleFontSize,
+				fontStyle : this.options.scaleFontStyle,
+				fontFamily : this.options.scaleFontFamily,
+				valuesCount : labels.length,
+				beginAtZero : this.options.scaleBeginAtZero,
+				integersOnly : this.options.scaleIntegersOnly,
+				calculateYRange: function(currentHeight){
+					var updatedRanges = helpers.calculateScaleRange(
+						dataTotal(),
+						currentHeight,
+						this.fontSize,
+						this.beginAtZero,
+						this.integersOnly
+					);
+					helpers.extend(this, updatedRanges);
+				},
+				xLabels : this.options.xLabels || labels,
+				font : helpers.fontString(this.options.scaleFontSize, this.options.scaleFontStyle, this.options.scaleFontFamily),
+				lineWidth : this.options.scaleLineWidth,
+				lineColor : this.options.scaleLineColor,
+				gridLineWidth : (this.options.scaleShowGridLines) ? this.options.scaleGridLineWidth : 0,
+				gridLineColor : (this.options.scaleShowGridLines) ? this.options.scaleGridLineColor : "rgba(0,0,0,0)",
+                showHorizontalLines : this.options.scaleShowHorizontalLines,
+				showVerticalLines : this.options.scaleShowVerticalLines,
+				padding : (this.options.showScale) ? 0 : (this.options.barShowStroke) ? this.options.barStrokeWidth : 0,
+				showLabels : this.options.scaleShowLabels,
+				display : this.options.showScale
+			};
+
+			if (this.options.scaleOverride){
+				helpers.extend(scaleOptions, {
+					calculateYRange: helpers.noop,
+					steps: this.options.scaleSteps,
+					stepValue: this.options.scaleStepWidth,
+					min: this.options.scaleStartValue,
+					max: this.options.scaleStartValue + (this.options.scaleSteps * this.options.scaleStepWidth)
+				});
+			}
+
+			this.scale = new this.ScaleClass(scaleOptions);
+		},
+		addData : function(valuesArray,label){
+			//Map the values array for each of the datasets
+			helpers.each(valuesArray,function(value,datasetIndex){
+				if (helpers.isNumber(value)){
+					//Add a new point for each piece of data, passing any required data to draw.
+					//Add 0 as value if !isNumber (e.g. empty values are useful when 0 values should be hidden in tooltip)
+					this.datasets[datasetIndex].bars.push(new this.BarClass({
+						value : helpers.isNumber(value)?value:0,
+						label : label,
+						x: this.scale.calculateBarX(this.scale.valuesCount+1),
+						y: this.scale.endPoint,
+						width : this.scale.calculateBarWidth(this.datasets.length),
+						base : this.scale.endPoint,
+						strokeColor : this.datasets[datasetIndex].strokeColor,
+						fillColor : this.datasets[datasetIndex].fillColor
+					}));
+				}
+			},this);
+
+			this.scale.addXLabel(label);
+			//Then re-render the chart.
+			this.update();
+		},
+		removeData : function(){
+			this.scale.removeXLabel();
+			//Then re-render the chart.
+			helpers.each(this.datasets,function(dataset){
+				dataset.bars.shift();
+			},this);
+			this.update();
+		},
+		reflow : function(){
+			helpers.extend(this.BarClass.prototype,{
+				y: this.scale.endPoint,
+				base : this.scale.endPoint
+			});
+			var newScaleProps = helpers.extend({
+				height : this.chart.height,
+				width : this.chart.width
+			});
+			this.scale.update(newScaleProps);
+		},
+		draw : function(ease){
+			var easingDecimal = ease || 1;
+			this.clear();
+
+			var ctx = this.chart.ctx;
+
+			this.scale.draw(easingDecimal);
+
+			//Draw all the bars for each dataset
+			helpers.each(this.datasets,function(dataset,datasetIndex){
+				helpers.each(dataset.bars,function(bar,index){
+					var y = this.scale.calculateBarY(this.datasets, datasetIndex, index, bar.value),
+						height = this.scale.calculateBarHeight(this.datasets, datasetIndex, index, bar.value);
+
+					//Transition then draw
+					if(bar.value > 0) {
+						bar.transition({
+							base : this.scale.endPoint - (Math.abs(height) - Math.abs(y)),
+							x : this.scale.calculateBarX(index),
+							y : Math.abs(y),
+							height : Math.abs(height),
+							width : this.scale.calculateBarWidth(this.datasets.length)
+						}, easingDecimal).draw();
+					}
+				},this);
+			},this);
+		}
+	});
+}));


### PR DESCRIPTION
# コストをカテゴリ別に、積み上げ式棒グラフで表示できるようにする

closes #16 
- 一旦、カテゴリ別に、毎月のグラフを表示できるところまで
- 以下、別途issueを切る
  - カテゴリ毎の色分け
  - マウスオーバーしたときのLegendが「■」なのを、わかるように修正する

![categorized_stackedbar_graph](https://cloud.githubusercontent.com/assets/1254996/8224469/78129d14-15c2-11e5-9aa8-5c4b91209e49.gif)
