### PR TITLE
Change color according to categories.

### DIFF
--- a/app/assets/javascripts/project.js.coffee
+++ b/app/assets/javascripts/project.js.coffee
@@ -3,14 +3,29 @@ $ ->
   xaxis = []
   graphdatasets = []
 
+  fillColorRed   = 0x00
+  fillColorGreen = 0x00
+  fillColorBlue  = 0x00
+  lp = 0
   $.each(costs, (category, data) ->
+    if lp % 3 == 0
+      fillColorRed = fillColorRed + 125
+    else if lp % 3 == 1
+      fillColorGreen = fillColorGreen + 125
+    else if lp % 3 == 2
+      fillColorBlue = fillColorBlue + 125
+
+    console.log fillColorRed
+    console.log fillColorGreen
+    console.log fillColorBlue
     graphdata = []
     graphdata.label         = category
-    graphdata.fillColor     = "rgba(220,220,220,0.5)"
-    graphdata.strokeColor   = "rgba(220,220,220,0.8)"
-    graphdata.highlightFill = "rgba(220,220,220,0.75)"
+    graphdata.fillColor     = "rgba(#{fillColorRed}, #{fillColorGreen}, #{fillColorBlue},0.5)"
+    graphdata.strokeColor   = "rgba(0,0,0,1)"
+    graphdata.highlightFill = "rgba(100,220,220,0.75)"
     graphdata.data          = data
     graphdatasets.push graphdata
+    lp = lp + 1
   )
 
   data = {
@@ -18,4 +33,6 @@ $ ->
     datasets: graphdatasets
   };
   ctx = document.getElementById("cost_graph_canvas").getContext("2d")
-  graph = new Chart(ctx).StackedBar(data)
+  graph = new Chart(ctx).StackedBar(data, {
+    barStrokeWidth: 1
+  })


### PR DESCRIPTION
# コスト積上グラフのカテゴリ別に色を分ける修正

closes #26 

![colorized_stackedbar_graph](https://cloud.githubusercontent.com/assets/1254996/8251368/ffa58594-16b6-11e5-8b99-12dbfe4ed36d.gif)
