### PR TITLE
Modified the legend on cost graph.

### DIFF
--- a/app/assets/javascripts/project.js.coffee
+++ b/app/assets/javascripts/project.js.coffee
@@ -32,6 +32,7 @@ $ ->
     labels: gon.months,
     datasets: graphdatasets
   };
+  Chart.defaults.global.multiTooltipTemplate = "<%if (datasetLabel){%><%=datasetLabel%>: <%}%><%= value %>"
   ctx = document.getElementById("cost_graph_canvas").getContext("2d")
   graph = new Chart(ctx).StackedBar(data, {
     barStrokeWidth: 1


### PR DESCRIPTION
# コストのグラフにmouse overしたときのLegendがわかりづらいので修正

closes #27 

![modified_legend_on_cost_graph](https://cloud.githubusercontent.com/assets/1254996/8270597/46613084-1822-11e5-847c-42ce7da708aa.gif)
